### PR TITLE
Fix clippy lints about needless lifetimes

### DIFF
--- a/src/simulation/factory.rs
+++ b/src/simulation/factory.rs
@@ -107,7 +107,7 @@ impl std::fmt::Display for Modulation {
     }
 }
 
-impl<'a, Dec: DecoderFactory> BerTestBuilder<'a, Dec> {
+impl<Dec: DecoderFactory> BerTestBuilder<'_, Dec> {
     /// Create a BER test.
     ///
     /// This function only defines the BER test. To run it it is necessary to

--- a/src/sparse/bfs.rs
+++ b/src/sparse/bfs.rs
@@ -56,7 +56,7 @@ pub struct BFSContext<'a> {
     h: &'a SparseMatrix,
 }
 
-impl<'a> BFSContext<'a> {
+impl BFSContext<'_> {
     pub fn new(h: &SparseMatrix, node: Node) -> BFSContext {
         let mut to_visit = VecDeque::new();
         to_visit.push_back(PathHead {


### PR DESCRIPTION
These lints have appeared in a newer version of clippy.