### PR TITLE
Improve parsing of arguments with clap

### DIFF
--- a/src/cli/mackay_neal.rs
+++ b/src/cli/mackay_neal.rs
@@ -55,25 +55,25 @@ pub struct Args {
     /// Seed
     seed: u64,
     /// Columns to backtrack
-    #[structopt(long, default_value = "0")]
+    #[arg(long, default_value_t = 0)]
     backtrack_cols: usize,
     /// Backtrack attemps
-    #[structopt(long, default_value = "0")]
+    #[arg(long, default_value_t = 0)]
     backtrack_trials: usize,
     /// Minimum girth
-    #[structopt(long)]
+    #[arg(long)]
     min_girth: Option<usize>,
     /// Girth trials
-    #[structopt(long, default_value = "0")]
+    #[arg(long, default_value_t = 0)]
     girth_trials: usize,
     /// Use uniform fill policy
-    #[structopt(long)]
+    #[arg(long)]
     uniform: bool,
     /// Maximum seed trials
-    #[structopt(long, default_value = "1000")]
+    #[arg(long, default_value_t = 1000)]
     seed_trials: u64,
     /// Try several seeds in parallel
-    #[structopt(long)]
+    #[arg(long)]
     search: bool,
 }
 

--- a/src/cli/peg.rs
+++ b/src/cli/peg.rs
@@ -24,7 +24,7 @@ use std::error::Error;
 
 /// PEG CLI arguments.
 #[derive(Debug, Parser)]
-#[structopt(about = "Generates LDPC codes using the Progressive Edge Growth algorithm")]
+#[command(about = "Generates LDPC codes using the Progressive Edge Growth algorithm")]
 pub struct Args {
     /// Number of rows
     num_rows: usize,
@@ -35,7 +35,7 @@ pub struct Args {
     /// Seed
     seed: u64,
     /// Performs girth calculation
-    #[structopt(long)]
+    #[arg(long)]
     girth: bool,
 }
 

--- a/src/decoder/factory.rs
+++ b/src/decoder/factory.rs
@@ -6,6 +6,7 @@
 
 use super::{LdpcDecoder, arithmetic::*, flooding, horizontal_layered};
 use crate::sparse::SparseMatrix;
+use clap::ValueEnum;
 use std::fmt::Display;
 
 /// Decoder factory.
@@ -27,7 +28,8 @@ pub trait DecoderFactory: Display + Clone + Sync + Send + 'static {
 ///
 /// This enum lists the LDPC decoder implementations corresponding to different
 /// arithmetic rules.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, ValueEnum)]
+#[clap(rename_all = "verbatim")]
 pub enum DecoderImplementation {
     /// The [`Phif64`] implementation, using `f64` and the involution
     /// `phi(x)`. This uses a flooding schedule.

--- a/src/simulation/factory.rs
+++ b/src/simulation/factory.rs
@@ -11,6 +11,7 @@ use crate::{
     decoder::factory::{DecoderFactory, DecoderImplementation},
     sparse::SparseMatrix,
 };
+use clap::ValueEnum;
 
 /// BER test.
 ///
@@ -74,7 +75,8 @@ pub struct BerTestBuilder<'a, Dec = DecoderImplementation> {
 /// Modulation.
 ///
 /// This enum represents the modulations that can be simulated.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, ValueEnum)]
+#[clap(rename_all = "UPPER")]
 pub enum Modulation {
     /// BPSK modulation.
     Bpsk,


### PR DESCRIPTION
- Use ValueEnum for enums. This allows the possible values to be shown in the help.

- Replace structopt -> arg.

- Replace default_value -> default_value_t in some places.