### PR TITLE
fixed new compiler and clippy warnings as of rustc 1.89.0

### DIFF
--- a/src/cli/ber.rs
+++ b/src/cli/ber.rs
@@ -259,6 +259,7 @@ impl Progress {
                 }
                 return Ok(());
             };
+            #[allow(clippy::collapsible_if)]
             if let Some(s) = &last_stats {
                 if s.ebn0_db != stats.ebn0_db {
                     if let Some(f) = &mut self.output_file {

--- a/src/mackay_neal.rs
+++ b/src/mackay_neal.rs
@@ -185,6 +185,7 @@ impl MacKayNeal {
     fn try_insert_column(&mut self) -> Result<()> {
         let rows = self.select_rows()?;
         self.h.insert_col(self.current_col, rows.into_iter());
+        #[allow(clippy::collapsible_if)]
         if let Some(g) = self.min_girth {
             if self
                 .h

--- a/src/sparse/bfs.rs
+++ b/src/sparse/bfs.rs
@@ -56,8 +56,8 @@ pub struct BFSContext<'a> {
     h: &'a SparseMatrix,
 }
 
-impl BFSContext<'_> {
-    pub fn new(h: &SparseMatrix, node: Node) -> BFSContext {
+impl<'a> BFSContext<'a> {
+    pub fn new(h: &'a SparseMatrix, node: Node) -> Self {
         let mut to_visit = VecDeque::new();
         to_visit.push_back(PathHead {
             node,


### PR DESCRIPTION
Fixes a couple of compiler and clippy warnings related to the latest lint changes.