### PR TITLE
Warn about / document insufficient row weight in PEG

### DIFF
--- a/src/cli/peg.rs
+++ b/src/cli/peg.rs
@@ -53,6 +53,16 @@ impl Run for Args {
     fn run(&self) -> Result<(), Box<dyn Error>> {
         let conf = self.config();
         let h = conf.run(self.seed)?;
+        for r in 0..h.num_rows() {
+            if h.row_weight(r) < 2 {
+                eprint!("warning: at least 1 row weight ≤ 1");
+                if conf.wc < 3 {
+                    eprint!(" (try col weight ≥ 3?)");
+                }
+                eprintln!();
+                break;
+            }
+        }
         println!("{}", h.alist());
         if self.girth {
             match h.girth() {

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -22,6 +22,10 @@
 //!
 //! This procedure tries to maximize local girth greedily and to fill the
 //! check nodes uniformly.
+//!
+//! Note that no check of row weights is currently performed. If any row has
+//! weight less than 2, the resulting matrix is likely to be poorly suited to
+//! decoding. It is suggested that the column weight `wc` be at least 3.
 
 use crate::rand::{Rng, *};
 use crate::sparse::{Node, SparseMatrix};


### PR DESCRIPTION
Adds a note in the documentation and a warning in the UI about probably-too-small row weight for the PEG generator. Since Mackay-Neal includes explicit row weight, it is less obvious that this needs these, but they could be included.

Includes / depends on PR #14